### PR TITLE
[BITS-458] - add some missing bits of functionality

### DIFF
--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2763,6 +2763,7 @@ class Subscription(StripeObject):
             trial_end == now)
         if create_an_invoice:
             self._create_invoice()
+        schedule_webhook(Event('customer.subscription.updated', self))
 
     @classmethod
     def _api_delete(cls, id):

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2769,6 +2769,7 @@ class Subscription(StripeObject):
     def _api_delete(cls, id):
         obj = Subscription._api_retrieve(id)
         obj.ended_at = int(time.time())
+        obj.canceled_at = obj.ended_at
         obj.status = 'canceled'
         schedule_webhook(Event('customer.subscription.deleted', obj))
         return obj

--- a/localstripe/resources.py
+++ b/localstripe/resources.py
@@ -2618,6 +2618,8 @@ class Subscription(StripeObject):
                 # Currently unimplemented, only False works as expected:
                 enable_incomplete_payments=False):
 
+        now = int(time.time())
+
         # Legacy support (stripe-php still uses these parameters instead of
         # providing `items: [...]`):
         if items is None and plan is not None:
@@ -2635,7 +2637,7 @@ class Subscription(StripeObject):
         try:
             if trial_end is not None:
                 if trial_end == 'now':
-                    trial_end = int(time.time())
+                    trial_end = now
                 assert type(trial_end) is int
                 assert trial_end > 1500000000
             if tax_percent is not None:
@@ -2745,7 +2747,7 @@ class Subscription(StripeObject):
         if cancel_at_period_end is not None:
             self.cancel_at_period_end = cancel_at_period_end
             if cancel_at_period_end:
-                self.canceled_at = int(time.time())
+                self.canceled_at = now
             else:
                 self.canceled_at = None
 
@@ -2757,7 +2759,8 @@ class Subscription(StripeObject):
         # be manually created using the POST /invoices route.
         create_an_invoice = self.plan.billing_scheme == 'per_unit' and (
             self.plan.interval != old_plan.interval or
-            self.plan.interval_count != old_plan.interval_count)
+            self.plan.interval_count != old_plan.interval_count or
+            trial_end == now)
         if create_an_invoice:
             self._create_invoice()
 


### PR DESCRIPTION
* allow type filter in event list api 
* trigger creating invoice when sub is updated to `trial_end == 'now' `
* fire `customer.subscription.updated` event when sub is updated
* update `canceled_at` when subscription is canceled

Related API PR: https://github.com/calm/api/pull/2349